### PR TITLE
Add installation manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,8 @@
 ros-env is a collection of simple tools for working with ROS source packages.
 
 ### Installation
-TODO: upload to PyPI
-
-For now, please install from source
-
-### Installation from source
-```sh
-mkdir -p src/
-cd src/
-git clone https://github.com/Rayman/ros-get.git
-cd ros-get/
-pip install --user -e ros-get/
-```
+For now, please install from source, for development.
+Details can be found in the [installation manual](doc/install.md).
 
 ### Usage
 ```sh

--- a/doc/install.md
+++ b/doc/install.md
@@ -1,0 +1,49 @@
+# Installation #
+While the *ros-get* program can use either Python2 or Python3, some of its
+dependencies still use Python2. For this reason, This installation guide
+explains how to install the software for Python 2.
+
+The *ros-get* software uses ``pip`` to install itself. If you don't have it
+yet, it is available as ``python-pip`` at Debian and Ubuntu. (Install using
+``sudo apt install python-pip``.)
+
+
+## Install from local source, for development ##
+If you like to both use and hack *ros-get*, you can 'install' the software by
+pointing the installation to the development code.
+
+1. Make *ros-get* available locally, eg by download or cloning the repository, for example
+
+    ``` shell
+    git checkout https://github.com/Rayman/ros-get.git
+    ```
+
+2. Install using ``pip`` with the *editable* option ``-e DIR``.
+
+    ``` shell
+    cd ros-get
+    pip install --user -e .
+    ```
+
+    The final ``.`` says that ``pip`` should redirect the ``ros-get`` command
+    relative to this directory (to ``./src/ros-get``).
+
+
+## Install from PyPI, for usage only ##
+
+Not yet available.
+
+
+## Install directly from github, for usage only ##
+If your only interest is using the software to build a robot, you can do
+a system-wide install directly from Github.
+Note that this way of installing does not provide a simple way to upgrade the software.
+
+If you like to install it in this way despite this disadvantage, you can do a system-wide install by typing
+
+    sudo pip install https://github.com/Rayman/ros-get/archive/master.zip
+
+or for a user-based install, do
+
+    pip install --user https://github.com/Rayman/ros-get/archive/master.zip
+


### PR DESCRIPTION
It seems we had the same idea at the same time :)

My version seems a bit more elaborate, although not sure that suggesting to install from a Github ZIP is useful. I added an empty 'install from PyPI' section to keep all information, and shuffled 'install from source for development' as first option, as per your suggested use.

In your version, the suggested ``-e ros-get/`` doesn't seem to work when I tested it (there is no ``ros-get`` in the root of the project).

Feel free to request any change.

Fixes #2
Fixes #11