### PR TITLE
get ros_distro from environment

### DIFF
--- a/src/ros_get/commands.py
+++ b/src/ros_get/commands.py
@@ -38,8 +38,8 @@ def install(pkgs, verbose):
 
 def update(verbose):
     # first check if a custom rosdistro has been configured
-    # TODO: get distro from environment
-    get_rosdistro('kinetic')
+    distro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
+    get_rosdistro(distro_name)
 
     logger.info('rosdep update')
     exit_code = command_update(None)
@@ -64,8 +64,8 @@ def update(verbose):
 
 
 def status(verbose):
-    # TODO: get distro from environment
-    distro = get_rosdistro('kinetic')
+    distro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
+    distro = get_rosdistro(distro_name)
     repositories = [
         r for r in distro.repositories.values() if r.source_repository and r.source_repository.patched_packages
     ]
@@ -113,8 +113,8 @@ def list_packages(installed, verbose):
         for pkg in get_pkgs_from_installed_list():
             print(pkg)
     else:
-        # TODO: get distro from environment
-        distro = get_rosdistro('kinetic')
+        distro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
+        distro = get_rosdistro(distro_name)
 
         pkgs = []
         for r in distro.repositories.values():
@@ -137,8 +137,8 @@ def recursive_update(pkgs, verbose):
         logger.warn('no package specified')
         return set()
 
-    # TODO: get distro from environment
-    distro = get_rosdistro('kinetic')
+    distro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
+    distro = get_rosdistro(distro_name)
     repositories = [
         r for r in distro.repositories.values() if r.source_repository and r.source_repository.patched_packages
     ]

--- a/src/ros_get/commands.py
+++ b/src/ros_get/commands.py
@@ -38,8 +38,11 @@ def install(pkgs, verbose):
 
 def update(verbose):
     # first check if a custom rosdistro has been configured
-    distro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
-    get_rosdistro(distro_name)
+    if 'ROS_DISTRO' in os.environ:
+        distro_n = os.environ['ROS_DISTRO']
+    else:
+        raise AssertionError('ROS_DISTRO is not defined in environment')
+    get_rosdistro(distro_n)
 
     logger.info('rosdep update')
     exit_code = command_update(None)
@@ -64,8 +67,12 @@ def update(verbose):
 
 
 def status(verbose):
-    distro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
-    distro = get_rosdistro(distro_name)
+    if 'ROS_DISTRO' in os.environ:
+        distro_n = os.environ['ROS_DISTRO']
+    else:
+        raise AssertionError('ROS_DISTRO is not defined in environment')
+    distro = get_rosdistro(distro_n)
+
     repositories = [
         r for r in distro.repositories.values() if r.source_repository and r.source_repository.patched_packages
     ]
@@ -113,8 +120,11 @@ def list_packages(installed, verbose):
         for pkg in get_pkgs_from_installed_list():
             print(pkg)
     else:
-        distro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
-        distro = get_rosdistro(distro_name)
+        if 'ROS_DISTRO' in os.environ:
+            distro_n = os.environ['ROS_DISTRO']
+        else:
+            raise AssertionError('ROS_DISTRO is not defined in environment')
+        distro = get_rosdistro(distro_n)
 
         pkgs = []
         for r in distro.repositories.values():
@@ -137,8 +147,12 @@ def recursive_update(pkgs, verbose):
         logger.warn('no package specified')
         return set()
 
-    distro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
-    distro = get_rosdistro(distro_name)
+    if 'ROS_DISTRO' in os.environ:
+        distro_n = os.environ['ROS_DISTRO']
+    else:
+        raise AssertionError('ROS_DISTRO is not defined in environment')
+    distro = get_rosdistro(distro_n)
+
     repositories = [
         r for r in distro.repositories.values() if r.source_repository and r.source_repository.patched_packages
     ]

--- a/src/ros_get/commands.py
+++ b/src/ros_get/commands.py
@@ -38,11 +38,7 @@ def install(pkgs, verbose):
 
 def update(verbose):
     # first check if a custom rosdistro has been configured
-    if 'ROS_DISTRO' in os.environ:
-        distro_n = os.environ['ROS_DISTRO']
-    else:
-        raise AssertionError('ROS_DISTRO is not defined in environment')
-    get_rosdistro(distro_n)
+    get_rosdistro()
 
     logger.info('rosdep update')
     exit_code = command_update(None)
@@ -67,11 +63,8 @@ def update(verbose):
 
 
 def status(verbose):
-    if 'ROS_DISTRO' in os.environ:
-        distro_n = os.environ['ROS_DISTRO']
-    else:
-        raise AssertionError('ROS_DISTRO is not defined in environment')
-    distro = get_rosdistro(distro_n)
+
+    distro = get_rosdistro()
 
     repositories = [
         r for r in distro.repositories.values() if r.source_repository and r.source_repository.patched_packages
@@ -120,11 +113,7 @@ def list_packages(installed, verbose):
         for pkg in get_pkgs_from_installed_list():
             print(pkg)
     else:
-        if 'ROS_DISTRO' in os.environ:
-            distro_n = os.environ['ROS_DISTRO']
-        else:
-            raise AssertionError('ROS_DISTRO is not defined in environment')
-        distro = get_rosdistro(distro_n)
+        distro = get_rosdistro()
 
         pkgs = []
         for r in distro.repositories.values():
@@ -147,11 +136,7 @@ def recursive_update(pkgs, verbose):
         logger.warn('no package specified')
         return set()
 
-    if 'ROS_DISTRO' in os.environ:
-        distro_n = os.environ['ROS_DISTRO']
-    else:
-        raise AssertionError('ROS_DISTRO is not defined in environment')
-    distro = get_rosdistro(distro_n)
+    distro = get_rosdistro()
 
     repositories = [
         r for r in distro.repositories.values() if r.source_repository and r.source_repository.patched_packages

--- a/src/ros_get/utils.py
+++ b/src/ros_get/utils.py
@@ -46,7 +46,12 @@ class SourceRepositorySpecificationMock(SourceRepositorySpecification):
         self.patched_packages = data.get('packages', [])
 
 
-def get_rosdistro(distroname):
+def get_rosdistro():
+    if 'ROS_DISTRO' in os.environ:
+        distroname = os.environ['ROS_DISTRO']
+    else:
+        raise AssertionError('ROS_DISTRO is not defined in environment')
+
     index_url = get_index_url()
     index = get_index(index_url)
 


### PR DESCRIPTION
if ros_distro is not in the environment the script will raise an error, so i could ask for an extra argument like this:

parser.add_argument('--rosdistro', required=distro_name is None, default=distro_name, help='The ROS distro (default: environment variable ROS_DISTRO if defined)')

but i think for this purpose, the proposed solution is sufficient.