### PR TITLE
Run pip without root when installing rosdeps

### DIFF
--- a/src/ros_get/utils.py
+++ b/src/ros_get/utils.py
@@ -128,6 +128,6 @@ def get_rosdep(key):
 
 
 def rosdep_install(path):
-    result = _rosdep_main(['install', '--from-paths', path, '-i', '-y'])
+    result = _rosdep_main(['install', '--from-paths', path, '-i', '-y', '--as-root', 'pip:false'])
     logger.info('rosdep exited with code %d', result)
     return result


### PR DESCRIPTION
@reinzor do you think this is a good default, or should this be configurable. I prefer all pip's in `~/.local` so that I can easily remove them and they don't mess with the system.