### PR TITLE
Fix "ImportError: cannot import name wraps" on trusty

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0-dev0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'colorlog',
         'future',
         'mock',
+        'six>=1.7',  # https://github.com/testing-cabal/mock/issues/257
         'rosdep',
         'rosdistro >= 0.7.3',
         'rosinstall_generator',

--- a/src/ros_get/__init__.py
+++ b/src/ros_get/__init__.py
@@ -1,7 +1,7 @@
 from .commands import install, update, status, list_packages, remove
 from .workspace import create, switch, save, list_workspaces, locate, name, rosdistro_url
 
-__version__ = '0.1.0'
+__version__ = '0.2.0-dev0'
 __url__ = 'https://github.com/Rayman/ros-get'
 __author__ = 'Ramon Wijnands'
 __email__ = 'rayman747@hotmail.com'


### PR DESCRIPTION
testing-cabal/mock#257