### PR TITLE
Fix AssertionError: Multiple .dist-info directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'catkin_tools',
         'colorlog',
         'future',
-        'mock',
+        "mock < 4; python_version < '3'",
         'six>=1.7',  # https://github.com/testing-cabal/mock/issues/257
         'rosdep',
         'rosdistro >= 0.7.3',

--- a/src/ros_get/utils.py
+++ b/src/ros_get/utils.py
@@ -7,11 +7,15 @@ from rosdep2.main import _rosdep_main
 from rosdistro import get_index, get_index_url, repository, get_distribution, DEFAULT_INDEX_URL
 from rosdistro.source_repository_specification import SourceRepositorySpecification
 
-from mock import patch
 from rosdep2 import RosdepLookup, create_default_installer_context, get_default_installer
 from rosdep2.rospkg_loader import DEFAULT_VIEW_KEY
 from rosinstall_generator.generator import generate_rosinstall_for_repos
 from vcstools import get_vcs_client
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Mock v4 is not compatible with Python 2. Unfortunately the pip version on 16.04 is too old to install the correct version. To fix this, pin mock at version 3 on Python 2, fix #91

