### PR TITLE
Add python version to the --version print

### DIFF
--- a/src/ros_get/__main__.py
+++ b/src/ros_get/__main__.py
@@ -25,7 +25,8 @@ class VersionAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
         from . import __version__
         formatter = parser._get_formatter()
-        formatter.add_text('%(prog)s version ' + __version__)
+        python_version = '.'.join(map(str, sys.version_info[:2]))
+        formatter.add_text('%(prog)s version ' + __version__ + ' (python ' + python_version + ')')
         parser.exit(message=formatter.format_help())
 
 


### PR DESCRIPTION
Small convenience feature. I sometimes forget if I installed ros-get under python2 or 3. This makes the output similar to pip:
```
pip --version
pip 20.1.1 from /usr/local/lib/python2.7/dist-packages/pip (python 2.7)

ros-get --version
ros-get version 0.3.3 (python 3.6)
```