### PR TITLE
feat: --rosdep-check-install

### DIFF
--- a/src/ros_get/__main__.py
+++ b/src/ros_get/__main__.py
@@ -41,11 +41,15 @@ def parse_args(argv):
     subparser = subparsers.add_parser('install', help='install packages')
     subparser.set_defaults(func='install')
     subparser.add_argument('pkgs', nargs='+', metavar='pkg')
+    subparser.add_argument('--rosdep-check-install', action='store_true',
+                           help='Perform a `rosdep check` instead of a `rosdep install`')
 
     subparser = subparsers.add_parser('update', help='update all packages in the workspace to the latest version')
     subparser.set_defaults(func='update')
     subparser.add_argument('--restore-versions', action='store_true',
                            help='Whether to restore the versions to the versions as defined in the rosdistro database')
+    subparser.add_argument('--rosdep-check-install', action='store_true',
+                           help='Perform a `rosdep check` instead of a `rosdep install`')
 
     subparser = subparsers.add_parser('status', help='check if there are modified files in the workspace')
     subparser.set_defaults(func='status')

--- a/src/ros_get/commands.py
+++ b/src/ros_get/commands.py
@@ -19,7 +19,7 @@ target_path = os.path.realpath(os.path.join(ws_file, 'repos'))
 link_dir = os.path.realpath(os.path.join(ws_file, 'src'))
 
 
-def install(pkgs, verbose):
+def install(pkgs, rosdep_check_install, verbose):
     pkgs_done = recursive_update(pkgs, False, verbose)
     pkgs_succeeded = [pkg for pkg in pkgs if pkg in pkgs_done]
     pkgs_skipped = set(pkgs) - pkgs_done
@@ -30,13 +30,13 @@ def install(pkgs, verbose):
 
     if not pkgs_done:
         return 1
-    result = rosdep_install(link_dir)
+    result = rosdep_install(link_dir, rosdep_check_install)
     if pkgs_skipped:
         return 1
     return result
 
 
-def update(restore_versions, verbose):
+def update(restore_versions, rosdep_check_install, verbose):
     # first check if a custom rosdistro has been configured
     get_rosdistro()
 
@@ -51,7 +51,7 @@ def update(restore_versions, verbose):
 
     cleanup_symlinks(pkgs_done)
 
-    exit_code = rosdep_install(link_dir)
+    exit_code = rosdep_install(link_dir, rosdep_check_install)
     if exit_code:
         logger.error('`rosdep install` exited with %d', exit_code)
         return exit_code

--- a/src/ros_get/utils.py
+++ b/src/ros_get/utils.py
@@ -135,7 +135,8 @@ def get_rosdep(key):
         return False
 
 
-def rosdep_install(path):
-    result = _rosdep_main(['install', '--from-paths', path, '-i', '-y', '--as-root', 'pip:false'])
+def rosdep_install(path, check_install=False):
+    rosdep_verb = 'check' if check_install else 'install'
+    result = _rosdep_main([rosdep_verb, '--from-paths', path, '-i', '-y', '--as-root', 'pip:false'])
     logger.info('rosdep exited with code %d', result)
     return result

--- a/test/test_list_installed.py
+++ b/test/test_list_installed.py
@@ -22,12 +22,12 @@ def test_fixture(empty_config_home):
 
 
 def test_install(empty_config_home):
-    assert install([], verbose=True) == 1
+    assert install([], rosdep_check_install=False, verbose=True) == 1
 
 
 @pytest.mark.skip()
 def test_update():
-    assert update(restore_versions=False, verbose=True) == 1
+    assert update(restore_versions=False, rosdep_check_install=False, verbose=True) == 1
 
 
 def test_list(empty_config_home):


### PR DESCRIPTION
Only verify the `rosdep` dependencies instead of downloading and
installing them. #99 